### PR TITLE
Invert bugfixes

### DIFF
--- a/py12box_invert/invert.py
+++ b/py12box_invert/invert.py
@@ -111,7 +111,8 @@ class Invert(Inverse_method, Plot):
             self.change_end_year(end_year)
         else:
             #Align to obs dataset by default
-            self.change_end_year(int(self.obs.time[-1])+1)
+            self.change_end_year(int(self.obs.time[-1])+1-1/12)
+            end_year = self.obs.time[-1]
 
         # Reference run
         print("Model reference run...")

--- a/py12box_invert/obs.py
+++ b/py12box_invert/obs.py
@@ -83,7 +83,7 @@ class Obs:
 
         elif float(start_year) < self.time[0]:
             # Pad with nans
-            new_time = arange(start_year, self.time[0]-1/12., step=1/12)
+            new_time = arange(start_year, self.time[0]-1e-8, step=1/12) # minus 1e-8 else numerical problem  
             self.time = hstack([new_time, self.time])
             nanarray = zeros((len(new_time), 4))*nan
             self.mf = vstack([nanarray, self.mf])
@@ -98,7 +98,7 @@ class Obs:
         end_year : flt
             New end year
         """
-
+        
         if float(end_year) < self.time[-1]:
             # Trim at new end date
             ti = bisect(self.time, float(end_year)) - 1
@@ -107,7 +107,7 @@ class Obs:
             self.mf_uncertainty = self.mf_uncertainty[:ti, :]
         elif float(end_year) > self.time[-1]:
             # Pad with nans
-            new_time = arange(self.time[-1] + 1/12, end_year - 1/12, step=1/12)
+            new_time = arange(self.time[-1] + 1/12, end_year, step=1/12)
             self.time = hstack([self.time, new_time])
             nanarray = zeros((len(new_time), 4))*nan
             self.mf = vstack([self.mf, nanarray])


### PR DESCRIPTION
Some bug fixes when it came to padding data. 
- end year alignment was extending to following year (e.g. 2022.0 instead of 2021.9166... ).
- Small numerical errors were causing problems with padding. i.e. np.arange(a,b,1/12) was including b due to small numerical differences and not being exactly a multiple of 1/12ths