### PR TITLE
Fix for numerical error when padding obs

### DIFF
--- a/py12box_invert/obs.py
+++ b/py12box_invert/obs.py
@@ -107,7 +107,7 @@ class Obs:
             self.mf_uncertainty = self.mf_uncertainty[:ti, :]
         elif float(end_year) > self.time[-1]:
             # Pad with nans
-            new_time = arange(self.time[-1] + 1/12, end_year, step=1/12)
+            new_time = arange(self.time[-1] + 1/12, end_year-1e-8, step=1/12)
             self.time = hstack([self.time, new_time])
             nanarray = zeros((len(new_time), 4))*nan
             self.mf = vstack([self.mf, nanarray])


### PR DESCRIPTION
Similar to an earlier bug. End time was being included in np.arange() when padding due to numerical rounding.
Fix is to just minus 1e-8.

It wasn't affecting tests as seemed to occur when obs weren't in whole years. Was introduced with fixes for tests.

Tests pass etc.