### PR TITLE
Difference operator: annual difference

### DIFF
--- a/notebooks/example_run.ipynb
+++ b/notebooks/example_run.ipynb
@@ -38,7 +38,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "inv = Invert(project_path, species, method=\"rigby14\", n_threads=4)"
+    "inv = Invert(project_path, species, method=\"rigby14\", n_threads=4, sensitivity_freq=\"quarterly\")"
    ]
   },
   {

--- a/py12box_invert/inversion_modules.py
+++ b/py12box_invert/inversion_modules.py
@@ -271,8 +271,7 @@ class Inverse_method:
         """
         
         # Difference operator
-        nx = len(self.mat.x_a)
-        D = difference_operator(nx, self.sensitivity.freq)
+        D = difference_operator(len(self.mat.x_a), int(12/self.sensitivity.freq_months))
 
         H = self.mat.H.copy()
 

--- a/py12box_invert/inversion_modules.py
+++ b/py12box_invert/inversion_modules.py
@@ -111,26 +111,26 @@ def calc_lifetime_uncertainty(lifetime_fractional_error, steady_state_lifetime, 
 def difference_operator(nx, freq):
     """Calculate differencing operator
 
-    Differenes are calculated between quantities separated by one year
+    Differences are calculated between quantities separated by one year
     Hence frequency term is required, which tells us the number of 
     elements between years
-
-    Assumes that there are four time series stacked vertically, one for 
-    each surface box (i.e. box 0 is 0 -> n/4-1, etc.)
 
     Parameters
     ----------
     nx : int
         Number of elements in state vector
     freq : int
-        Number of state vector elements between subsequent years
+        Number of state vector elements between years
     """
 
     D = np.zeros((nx, nx))
-    for xi in range(nx):
-        if (xi % (nx/4)) < (nx/4 - freq):
-            D[xi, xi] = -1.
-            D[xi, xi + freq] = 1.
+
+    for bi in range(4):
+        for yi in range(int(nx/freq/4)-1):
+            for fi in range(freq):
+                xi = 4*(yi*freq + fi) + bi
+                D[xi, xi] = -1.
+                D[xi, xi + 4*freq] = 1.
     
     return D
 
@@ -140,6 +140,10 @@ class Inverse_method:
 
     Each method must have a corresponding {method}_posterior function that allows
     posterior mole fraction and emissions matrices to be calculated
+
+    Each method must also have a corresponding {method}_posterior_ensemble function
+    that calculates an ensemble of model outputs (potentially including systematic
+    uncertainties)
     """
 
     def analytical_gaussian(self):

--- a/tests/test_inversion_modules.py
+++ b/tests/test_inversion_modules.py
@@ -1,0 +1,28 @@
+import numpy as np
+
+from py12box_invert.inversion_modules import difference_operator
+
+
+def test_difference_operator():
+
+    for freq in [1, 4, 12]:
+
+        nyears=10
+
+        emissions = np.vstack([np.arange(0., 1000., 100./freq),
+                                np.arange(0., 100., 10./freq),
+                                np.arange(0., 10., 1./freq),
+                                np.arange(0., 1., 0.1/freq)]).T
+
+        x = emissions.flatten()
+
+        difference = difference_operator(len(x), freq) @ x
+
+        emissions_difference = difference.reshape((int(len(x)/4), 4))
+
+        actual_diffs = np.vstack([emissions[ti + freq, :] - emissions[ti, :] for ti in range(freq*(nyears-1))])
+
+        # Check that all differences are correct up to last year
+        assert np.allclose(actual_diffs, emissions_difference[:freq*(nyears-1), :])
+        # Final year should only contain zeros
+        assert np.sum(emissions_difference[(nyears-1)*freq:, :]) == 0.

--- a/tests/test_inversion_modules.py
+++ b/tests/test_inversion_modules.py
@@ -9,6 +9,9 @@ def test_difference_operator():
 
         nyears=10
 
+        # Some fake emissions.
+        # Increasing values in each box.
+        # Difference rate of increase in each box
         emissions = np.vstack([np.arange(0., 1000., 100./freq),
                                 np.arange(0., 100., 10./freq),
                                 np.arange(0., 10., 1./freq),
@@ -16,10 +19,13 @@ def test_difference_operator():
 
         x = emissions.flatten()
 
+        # Calculate emissions difference using difference operator
         difference = difference_operator(len(x), freq) @ x
 
+        # Reshape to time x box array
         emissions_difference = difference.reshape((int(len(x)/4), 4))
 
+        # Manually calculate the difference in the emissions array
         actual_diffs = np.vstack([emissions[ti + freq, :] - emissions[ti, :] for ti in range(freq*(nyears-1))])
 
         # Check that all differences are correct up to last year


### PR DESCRIPTION
I've modified the difference operator so that it constrains the growth between quantities separated by one year. Previously, it was between consecutive years/months/seasons, whereas the IDL code had it so that it'd constrain each month/season to the same month/season in the following/previous year.

Any chance you could write a test for this? It particularly needs checking for the final year...