### PR TITLE
Hacky fix for problems with numerical errors and bisect

### DIFF
--- a/py12box_invert/invert.py
+++ b/py12box_invert/invert.py
@@ -295,9 +295,8 @@ class Invert(Inverse_method):
         end_year : flt
             New end year
         """
-
         self.obs.change_end_year(end_year)
-        self.mod.change_end_year(end_year-1/12)
+        self.mod.change_end_year(end_year-1/12+1e-4)
         #TODO: Add sensitivity?
 
 


### PR DESCRIPTION
There was a problem where bisect was picking time t rather than time t+1.
This isn't very elegant but fixes the problem.