### PR TITLE
Fix to issue #25

### DIFF
--- a/py12box_invert/invert.py
+++ b/py12box_invert/invert.py
@@ -134,7 +134,7 @@ class Invert(Inverse_method):
             self.change_end_year(end_year)
         else:
             #Align to obs dataset by default
-            self.change_end_year(int(self.obs.time[-1])+1)
+            self.change_end_year(int(self.obs.time[-1]))
             end_year = self.obs.time[-1]
 
         # Reference run, this will likely change, but need something to kick things off
@@ -295,10 +295,9 @@ class Invert(Inverse_method):
         end_year : flt
             New end year
         """
+        self.mod.change_end_year(end_year)
         self.obs.change_end_year(end_year)
-        self.mod.change_end_year(end_year-1/12+1e-4)
         #TODO: Add sensitivity?
-
 
     def run_sensitivity(self, freq="yearly", nthreads=12):
         """

--- a/py12box_invert/obs.py
+++ b/py12box_invert/obs.py
@@ -98,8 +98,8 @@ class Obs:
         end_year : flt
             New end year
         """
-        
-        if float(end_year) < self.time[-1]:
+        if float(end_year) <= self.time[-1]:
+            print("Goes down here")
             # Trim at new end date
             ti = bisect(self.time, float(end_year)) - 1
             self.time = self.time[:ti]

--- a/py12box_invert/obs.py
+++ b/py12box_invert/obs.py
@@ -99,7 +99,6 @@ class Obs:
             New end year
         """
         if float(end_year) <= self.time[-1]:
-            print("Goes down here")
             # Trim at new end date
             ti = bisect(self.time, float(end_year)) - 1
             self.time = self.time[:ti]


### PR DESCRIPTION
Linked to https://github.com/mrghg/py12box/pull/19 and fixes issue #25 

End_year now fixed. Required a change to both py12box and py12box_invert.

Seemed to only introduce a problem if the end year was the same as the final year of the emissions, now fixed.

